### PR TITLE
Migrate protobuf dependency to rust-protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,12 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,8 +1632,8 @@ dependencies = [
  "identus-apollo",
  "identus-did-core",
  "im-rc",
- "prost",
- "prost-build",
+ "protobuf",
+ "protobuf-codegen",
  "regex",
  "serde_json",
  "tracing",
@@ -1658,7 +1652,7 @@ dependencies = [
  "identus-did-prism",
  "oura",
  "pallas-primitives",
- "prost",
+ "protobuf",
  "serde",
  "strum 0.27.1",
  "tokio",
@@ -1717,7 +1711,6 @@ dependencies = [
  "indexer-storage",
  "lazybe",
  "maud",
- "prost",
  "serde",
  "serde_json",
  "sqlx",
@@ -1740,7 +1733,7 @@ dependencies = [
  "identus-did-prism",
  "identus-did-prism-indexer",
  "lazybe",
- "prost",
+ "protobuf",
  "sea-query",
  "serde",
  "sqlx",
@@ -1824,15 +1817,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1977,6 +1961,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2169,12 +2159,6 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "net2"
@@ -2504,16 +2488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.9.0",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,16 +2548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -2658,55 +2622,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
+name = "protobuf"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
-dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
- "log",
- "multimap",
  "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.101",
- "tempfile",
+ "protobuf-support",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.13.5"
+name = "protobuf-codegen"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.13.5"
+name = "protobuf-parse"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
- "prost",
+ "anyhow",
+ "indexmap 2.9.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2902,6 +2865,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -2909,7 +2885,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3553,7 +3529,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -4142,6 +4118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,5 @@ sea-query = "0.32"
 oura = { git = "https://github.com/patextreme/oura.git", rev = "dd10323ecf95dcd7dd45edb46ef566d19af2eff8" }
 pallas-primitives = "0.30"
 # proto
-prost = "0.13"
-prost-types = "0.13"
-prost-build = "0.13"
+protobuf = "3"
+protobuf-codegen = "3"

--- a/lib/did-prism-indexer/Cargo.toml
+++ b/lib/did-prism-indexer/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = { workspace = true, features = [
 ] }
 oura = { workspace = true, optional = true }
 pallas-primitives = { workspace = true, optional = true }
-prost = { workspace = true }
+protobuf = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync", "time", "rt"] }

--- a/lib/did-prism-indexer/src/dlt/error.rs
+++ b/lib/did-prism-indexer/src/dlt/error.rs
@@ -32,7 +32,7 @@ pub(crate) enum MetadataReadError {
     },
     #[display("cannot decode prism_block protobuf on block {block_hash:?} tx {tx_idx:?}")]
     PrismBlockProtoDecode {
-        source: prost::DecodeError,
+        source: protobuf::Error,
         block_hash: Option<String>,
         tx_idx: Option<usize>,
     },

--- a/lib/did-prism-indexer/src/dlt/oura.rs
+++ b/lib/did-prism-indexer/src/dlt/oura.rs
@@ -21,9 +21,9 @@ use crate::repo::DltCursorRepo;
 mod model {
     use chrono::{DateTime, Utc};
     use identus_did_prism::dlt::{BlockMetadata, PublishedPrismObject};
-    use identus_did_prism::proto::PrismObject;
+    use identus_did_prism::prelude::*;
+    use identus_did_prism::proto::prism::PrismObject;
     use oura::model::{EventContext, MetadataRecord};
-    use prost::Message;
     use serde::{Deserialize, Serialize};
 
     use crate::dlt::error::MetadataReadError;

--- a/lib/did-prism-indexer/src/indexing.rs
+++ b/lib/did-prism-indexer/src/indexing.rs
@@ -2,8 +2,8 @@ use identus_apollo::hash::Sha256Digest;
 use identus_apollo::hex::HexStr;
 use identus_did_prism::did::CanonicalPrismDid;
 use identus_did_prism::dlt::OperationMetadata;
-use identus_did_prism::proto::prism_operation::Operation;
-use identus_did_prism::proto::{PrismOperation, SignedPrismOperation};
+use identus_did_prism::prelude::*;
+use identus_did_prism::proto::prism::prism_operation::Operation;
 
 use crate::DltSource;
 use crate::repo::{IndexedOperation, OperationRepo};
@@ -163,7 +163,7 @@ where
 }
 
 fn index_from_signed_operation(signed_operation: SignedPrismOperation) -> anyhow::Result<IntermediateIndexedOperation> {
-    match signed_operation.operation {
+    match signed_operation.operation.into_option() {
         Some(operation) => index_from_operation(operation),
         None => Err(anyhow::anyhow!("operation does not exist in PrismOperation")),
     }
@@ -197,5 +197,11 @@ fn index_from_operation(prism_operation: PrismOperation) -> anyhow::Result<Inter
             prev_operation_hash: op.previous_operation_hash,
         }),
         None => Err(anyhow::anyhow!("operation does not exist in PrismOperation")),
+        Some(_) => {
+            let operation_hash_hex = HexStr::from(operation_hash.as_bytes());
+            Err(anyhow::anyhow!(
+                "operation type in PrismOperation is not support (operation_hash: {operation_hash_hex})"
+            ))
+        }
     }
 }

--- a/lib/did-prism-indexer/src/repo.rs
+++ b/lib/did-prism-indexer/src/repo.rs
@@ -1,7 +1,7 @@
 use identus_apollo::hash::Sha256Digest;
 use identus_did_prism::did::CanonicalPrismDid;
 use identus_did_prism::dlt::{DltCursor, OperationMetadata};
-use identus_did_prism::proto::SignedPrismOperation;
+use identus_did_prism::prelude::*;
 use identus_did_prism::utils::paging::Paginated;
 use uuid::Uuid;
 

--- a/lib/did-prism/Cargo.toml
+++ b/lib/did-prism/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = { workspace = true, features = [
 ] }
 enum_dispatch = { workspace = true }
 im-rc = { workspace = true }
-prost = { workspace = true }
+protobuf = { workspace = true }
 regex = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
@@ -34,7 +34,7 @@ identus-apollo = { workspace = true, features = [
 ] }
 
 [build-dependencies]
-prost-build = { workspace = true }
+protobuf-codegen = { workspace = true }
 
 [features]
 default = []

--- a/lib/did-prism/build.rs
+++ b/lib/did-prism/build.rs
@@ -1,12 +1,14 @@
+use protobuf_codegen::Codegen;
+
 fn main() {
-    prost_build::compile_protos(
-        &[
+    Codegen::new()
+        .include("proto")
+        .inputs([
             "proto/prism.proto",
             "proto/prism-ssi.proto",
             "proto/prism-storage.proto",
             "proto/prism-version.proto",
-        ],
-        &["proto/"],
-    )
-    .unwrap();
+        ])
+        .cargo_out_dir("generated")
+        .run_from_script();
 }

--- a/lib/did-prism/src/did/error.rs
+++ b/lib/did-prism/src/did/error.rs
@@ -51,7 +51,7 @@ pub enum DidSyntaxError {
         encoded_state: String,
     },
     #[display("did suffix {did} cannot be decoded into protobuf message")]
-    DidEncodedStateInvalidProto { source: prost::DecodeError, did: String },
+    DidEncodedStateInvalidProto { source: protobuf::Error, did: String },
     #[display("unrecognized did pattern {did}")]
     DidSyntaxInvalid {
         #[error(not(source))]

--- a/lib/did-prism/src/did/mod.rs
+++ b/lib/did-prism/src/did/mod.rs
@@ -8,13 +8,13 @@ use identus_apollo::base64::Base64UrlStrNoPad;
 use identus_apollo::hash::Sha256Digest;
 use identus_apollo::hex::HexStr;
 use identus_did_core::Did;
-use prost::Message;
 use regex::Regex;
 
 use self::operation::{PublicKey, Service};
 use crate::did::operation::StorageData;
-use crate::proto::PrismOperation;
-use crate::proto::prism_operation::Operation;
+use crate::prelude::*;
+use crate::proto::prism::PrismOperation;
+use crate::proto::prism::prism_operation::Operation;
 
 pub mod did_doc;
 pub mod error;

--- a/lib/did-prism/src/did/operation/storage.rs
+++ b/lib/did-prism/src/did/operation/storage.rs
@@ -3,9 +3,9 @@ use identus_apollo::hex::HexStr;
 
 use crate::did::CanonicalPrismDid;
 use crate::did::error::{CreateStorageOperationError, DeactivateStorageOperationError, UpdateStorageOperationError};
-use crate::proto::proto_create_storage_entry::Data as ProtoCreateStorageData;
-use crate::proto::proto_update_storage_entry::Data as ProtoUpdateStorageData;
-use crate::proto::{ProtoCreateStorageEntry, ProtoDeactivateStorageEntry, ProtoUpdateStorageEntry};
+use crate::proto::prism_storage::proto_create_storage_entry::Data as ProtoCreateStorageData;
+use crate::proto::prism_storage::proto_update_storage_entry::Data as ProtoUpdateStorageData;
+use crate::proto::prism_storage::{ProtoCreateStorageEntry, ProtoDeactivateStorageEntry, ProtoUpdateStorageEntry};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusListData {

--- a/lib/did-prism/src/dlt.rs
+++ b/lib/did-prism/src/dlt.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::proto::PrismObject;
+use crate::proto::prism::PrismObject;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DltCursor {

--- a/lib/did-prism/src/lib.rs
+++ b/lib/did-prism/src/lib.rs
@@ -18,12 +18,12 @@ pub mod proto {
 
     include!(concat!(env!("OUT_DIR"), "/generated/mod.rs"));
 
-    pub trait ProtoExt: Sized {
+    pub trait MessageExt: Sized {
         fn encode_to_vec(&self) -> Vec<u8>;
         fn decode(bytes: &[u8]) -> protobuf::Result<Self>;
     }
 
-    impl<T: Message> ProtoExt for T {
+    impl<T: Message> MessageExt for T {
         fn encode_to_vec(&self) -> Vec<u8> {
             self.write_to_bytes().expect("Unable to encode protobuf message to vec")
         }

--- a/lib/did-prism/src/lib.rs
+++ b/lib/did-prism/src/lib.rs
@@ -12,9 +12,26 @@ pub mod test_utils;
 #[allow(clippy::doc_lazy_continuation)]
 pub mod proto {
     use identus_apollo::hash::{Sha256Digest, sha256};
-    use prost::Message;
+    use protobuf::Message;
 
-    include!(concat!(env!("OUT_DIR"), "/proto.rs"));
+    use crate::proto::prism::{PrismOperation, SignedPrismOperation};
+
+    include!(concat!(env!("OUT_DIR"), "/generated/mod.rs"));
+
+    pub trait ProtoExt: Sized {
+        fn encode_to_vec(&self) -> Vec<u8>;
+        fn decode(bytes: &[u8]) -> protobuf::Result<Self>;
+    }
+
+    impl<T: Message> ProtoExt for T {
+        fn encode_to_vec(&self) -> Vec<u8> {
+            self.write_to_bytes().expect("Unable to encode protobuf message to vec")
+        }
+
+        fn decode(bytes: &[u8]) -> protobuf::Result<Self> {
+            Self::parse_from_bytes(bytes)
+        }
+    }
 
     impl PrismOperation {
         pub fn operation_hash(&self) -> Sha256Digest {

--- a/lib/did-prism/src/prelude.rs
+++ b/lib/did-prism/src/prelude.rs
@@ -1,4 +1,5 @@
-pub use prost::Message;
+pub use protobuf::Message;
 
 pub use crate::did::{CanonicalPrismDid, DidState, LongFormPrismDid, PrismDid, PrismDidOps};
-pub use crate::proto::{PrismOperation, SignedPrismOperation};
+pub use crate::proto::ProtoExt;
+pub use crate::proto::prism::{PrismOperation, SignedPrismOperation};

--- a/lib/did-prism/src/prelude.rs
+++ b/lib/did-prism/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use protobuf::Message;
 
 pub use crate::did::{CanonicalPrismDid, DidState, LongFormPrismDid, PrismDid, PrismDidOps};
-pub use crate::proto::ProtoExt;
+pub use crate::proto::MessageExt;
 pub use crate::proto::prism::{PrismOperation, SignedPrismOperation};

--- a/lib/did-prism/src/protocol/resolver.rs
+++ b/lib/did-prism/src/protocol/resolver.rs
@@ -3,8 +3,7 @@ use std::collections::VecDeque;
 use super::{OperationProcessingContext, ProcessError, Published, init_published_context};
 use crate::did::DidState;
 use crate::dlt::OperationMetadata;
-use crate::prelude::PrismOperation;
-use crate::proto::SignedPrismOperation;
+use crate::prelude::*;
 use crate::protocol::init_unpublished_context;
 
 type OperationList = VecDeque<(OperationMetadata, SignedPrismOperation)>;

--- a/lib/did-prism/src/test_utils/mod.rs
+++ b/lib/did-prism/src/test_utils/mod.rs
@@ -1,9 +1,9 @@
 use chrono::DateTime;
 use identus_apollo::crypto::secp256k1::Secp256k1PrivateKey;
 use identus_apollo::hash::Sha256Digest;
-use prost::Message;
 
 use crate::dlt::{BlockMetadata, OperationMetadata};
+use crate::prelude::*;
 use crate::proto;
 
 const MASTER_KEY: [u8; 32] = [1; 32];
@@ -12,32 +12,41 @@ const MASTER_KEY_NAME: &str = "master-0";
 #[derive(Default)]
 pub struct CreateDidOptions {
     pub contexts: Option<Vec<String>>,
-    pub public_keys: Option<Vec<proto::PublicKey>>,
-    pub services: Option<Vec<proto::Service>>,
+    pub public_keys: Option<Vec<proto::prism_ssi::PublicKey>>,
+    pub services: Option<Vec<proto::prism_ssi::Service>>,
 }
 
 pub fn new_create_did_operation(
     options: Option<CreateDidOptions>,
-) -> (proto::SignedPrismOperation, Sha256Digest, Secp256k1PrivateKey) {
+) -> (proto::prism::SignedPrismOperation, Sha256Digest, Secp256k1PrivateKey) {
     let options = options.unwrap_or_default();
     let master_sk = Secp256k1PrivateKey::from_slice(&MASTER_KEY).unwrap();
-    let mut public_keys = vec![new_public_key(MASTER_KEY_NAME, proto::KeyUsage::MasterKey, &master_sk)];
+    let mut public_keys = vec![new_public_key(
+        MASTER_KEY_NAME,
+        proto::prism_ssi::KeyUsage::MASTER_KEY,
+        &master_sk,
+    )];
     public_keys.extend_from_slice(&options.public_keys.unwrap_or_default());
-    let operation_inner = proto::prism_operation::Operation::CreateDid(proto::ProtoCreateDid {
-        did_data: Some(proto::proto_create_did::DidCreationData {
+    let operation_inner = proto::prism::prism_operation::Operation::CreateDid(proto::prism_ssi::ProtoCreateDID {
+        did_data: Some(proto::prism_ssi::proto_create_did::DIDCreationData {
             public_keys,
             services: options.services.unwrap_or_default(),
             context: options.contexts.unwrap_or_default(),
-        }),
+            special_fields: Default::default(),
+        })
+        .into(),
+        special_fields: Default::default(),
     });
-    let operation = proto::PrismOperation {
+    let operation = proto::prism::PrismOperation {
         operation: Some(operation_inner),
+        special_fields: Default::default(),
     };
     let operation_hash = operation.operation_hash();
-    let signed_operation = proto::SignedPrismOperation {
+    let signed_operation = proto::prism::SignedPrismOperation {
         signed_with: MASTER_KEY_NAME.to_string(),
         signature: master_sk.sign(&operation.encode_to_vec()),
-        operation: Some(operation),
+        operation: Some(operation).into(),
+        special_fields: Default::default(),
     };
     (signed_operation, operation_hash, master_sk)
 }
@@ -45,37 +54,45 @@ pub fn new_create_did_operation(
 pub fn new_signed_operation(
     signed_with: &str,
     signing_key: &Secp256k1PrivateKey,
-    operation: proto::prism_operation::Operation,
-) -> (proto::SignedPrismOperation, Sha256Digest) {
-    let operation = proto::PrismOperation {
+    operation: proto::prism::prism_operation::Operation,
+) -> (proto::prism::SignedPrismOperation, Sha256Digest) {
+    let operation = proto::prism::PrismOperation {
         operation: Some(operation),
+        special_fields: Default::default(),
     };
     let operation_hash = operation.operation_hash();
-    let signed_operation = proto::SignedPrismOperation {
+    let signed_operation = proto::prism::SignedPrismOperation {
         signed_with: signed_with.to_string(),
         signature: signing_key.sign(&operation.encode_to_vec()),
-        operation: Some(operation),
+        operation: Some(operation).into(),
+        special_fields: Default::default(),
     };
     (signed_operation, operation_hash)
 }
 
-pub fn new_public_key(id: &str, usage: proto::KeyUsage, sk: &Secp256k1PrivateKey) -> proto::PublicKey {
+pub fn new_public_key(
+    id: &str,
+    usage: proto::prism_ssi::KeyUsage,
+    sk: &Secp256k1PrivateKey,
+) -> proto::prism_ssi::PublicKey {
     let pk = sk.to_public_key();
-    proto::PublicKey {
+    proto::prism_ssi::PublicKey {
         id: id.to_string(),
         usage: usage.into(),
-        key_data: Some(proto::public_key::KeyData::CompressedEcKeyData(
-            proto::CompressedEcKeyData {
+        key_data: Some(proto::prism_ssi::public_key::Key_data::CompressedEcKeyData(
+            proto::prism_ssi::CompressedECKeyData {
                 curve: "secp256k1".to_string(),
                 data: pk.encode_compressed().into(),
+                special_fields: Default::default(),
             },
         )),
+        special_fields: Default::default(),
     }
 }
 
 pub fn populate_metadata(
-    operations: Vec<proto::SignedPrismOperation>,
-) -> Vec<(OperationMetadata, proto::SignedPrismOperation)> {
+    operations: Vec<proto::prism::SignedPrismOperation>,
+) -> Vec<(OperationMetadata, proto::prism::SignedPrismOperation)> {
     let dummy_metadata = OperationMetadata {
         block_metadata: BlockMetadata {
             slot_number: 0,

--- a/lib/did-prism/tests/scala_did_compat.rs
+++ b/lib/did-prism/tests/scala_did_compat.rs
@@ -4,15 +4,15 @@ use std::str::FromStr;
 use identus_apollo::hex::HexStr;
 use identus_did_prism::did::CanonicalPrismDid;
 use identus_did_prism::did::operation::StorageData;
+use identus_did_prism::prelude::*;
 use identus_did_prism::protocol::resolver;
-use identus_did_prism::{proto, test_utils};
-use prost::Message;
+use identus_did_prism::test_utils;
 
 #[test]
 fn input_from_scala_did() {
     let parse_signed_operation = |hex_str: &str| {
         let bytes = HexStr::from_str(hex_str).unwrap();
-        proto::SignedPrismOperation::decode(bytes.to_bytes().as_slice()).unwrap()
+        SignedPrismOperation::decode(bytes.to_bytes().as_slice()).unwrap()
     };
 
     let create_did_op = parse_signed_operation(

--- a/lib/did-prism/tests/ssi_operation.rs
+++ b/lib/did-prism/tests/ssi_operation.rs
@@ -29,8 +29,8 @@ fn create_did_with_non_master_key() {
     let auth_sk = Secp256k1PrivateKey::from_slice(&[3; 32]).unwrap();
     let options = test_utils::CreateDidOptions {
         public_keys: Some(vec![
-            test_utils::new_public_key("vdr-0", proto::KeyUsage::VdrKey, &vdr_sk),
-            test_utils::new_public_key("auth-0", proto::KeyUsage::AuthenticationKey, &auth_sk),
+            test_utils::new_public_key("vdr-0", proto::prism_ssi::KeyUsage::VDR_KEY, &vdr_sk),
+            test_utils::new_public_key("auth-0", proto::prism_ssi::KeyUsage::AUTHENTICATION_KEY, &auth_sk),
         ]),
         ..Default::default()
     };

--- a/lib/did-prism/tests/storage_operation.rs
+++ b/lib/did-prism/tests/storage_operation.rs
@@ -16,10 +16,13 @@ fn create_storage_entry() {
     let (create_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -36,19 +39,25 @@ fn create_multiple_storage_entries() {
     let (create_storage_op_1, create_storage_op_hash_1) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (create_storage_op_2, create_storage_op_hash_2) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![1],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -82,18 +91,25 @@ fn update_storage_entry() {
     let (create_storage_op, create_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (update_storage_op, update_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: create_storage_op_hash.to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ]))
+            .into(),
+            special_fields: Default::default(),
         }),
     );
 
@@ -112,18 +128,24 @@ fn deactivate_storage_entry() {
     let (create_storage_op, create_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (deactivate_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::DeactivateStorageEntry(proto::ProtoDeactivateStorageEntry {
-            previous_operation_hash: create_storage_op_hash.to_vec(),
-        }),
+        proto::prism::prism_operation::Operation::DeactivateStorageEntry(
+            proto::prism_storage::ProtoDeactivateStorageEntry {
+                previous_operation_hash: create_storage_op_hash.to_vec(),
+                special_fields: Default::default(),
+            },
+        ),
     );
 
     let operations = test_utils::populate_metadata(vec![create_did_op, create_storage_op, deactivate_storage_op]);
@@ -138,10 +160,13 @@ fn create_storage_entry_with_non_vdr_key() {
     let (create_storage_op, _) = test_utils::new_signed_operation(
         "master-0",
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -157,18 +182,24 @@ fn update_storage_entry_with_invalid_prev_operation_hash() {
     let (create_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (update_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: [0; 32].to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -185,18 +216,24 @@ fn update_storage_entry_with_non_vdr_key() {
     let (create_storage_op, create_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (update_storage_op, _) = test_utils::new_signed_operation(
         "master-0",
         &master_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: create_storage_op_hash.to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -213,31 +250,42 @@ fn update_storage_entry_with_revoked_key() {
     let (create_storage_op, create_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (revoke_key_op, revoke_key_op_hash) = test_utils::new_signed_operation(
         "master-0",
         &master_sk,
-        proto::prism_operation::Operation::UpdateDid(proto::ProtoUpdateDid {
+        proto::prism::prism_operation::Operation::UpdateDid(proto::prism_ssi::ProtoUpdateDID {
             previous_operation_hash: create_storage_op_hash.to_vec(),
             id: did.suffix_hex().to_string(),
-            actions: vec![proto::UpdateDidAction {
-                action: Some(proto::update_did_action::Action::RemoveKey(proto::RemoveKeyAction {
-                    key_id: VDR_KEY_NAME.to_string(),
-                })),
+            actions: vec![proto::prism_ssi::UpdateDIDAction {
+                action: Some(proto::prism_ssi::update_didaction::Action::RemoveKey(
+                    proto::prism_ssi::RemoveKeyAction {
+                        keyId: VDR_KEY_NAME.to_string(),
+                        special_fields: Default::default(),
+                    },
+                )),
+                special_fields: Default::default(),
             }],
+            special_fields: Default::default(),
         }),
     );
     let (update_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: revoke_key_op_hash.to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -255,23 +303,31 @@ fn create_storage_entry_with_revoked_key() {
     let (revoke_key_op, _) = test_utils::new_signed_operation(
         "master-0",
         &master_sk,
-        proto::prism_operation::Operation::UpdateDid(proto::ProtoUpdateDid {
+        proto::prism::prism_operation::Operation::UpdateDid(proto::prism_ssi::ProtoUpdateDID {
             previous_operation_hash: create_did_op_hash.to_vec(),
             id: did.suffix_hex().to_string(),
-            actions: vec![proto::UpdateDidAction {
-                action: Some(proto::update_did_action::Action::RemoveKey(proto::RemoveKeyAction {
-                    key_id: VDR_KEY_NAME.to_string(),
-                })),
+            actions: vec![proto::prism_ssi::UpdateDIDAction {
+                action: Some(proto::prism_ssi::update_didaction::Action::RemoveKey(
+                    proto::prism_ssi::RemoveKeyAction {
+                        keyId: VDR_KEY_NAME.to_string(),
+                        special_fields: Default::default(),
+                    },
+                )),
+                special_fields: Default::default(),
             }],
+            special_fields: Default::default(),
         }),
     );
     let (create_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
@@ -288,18 +344,24 @@ fn deactivate_storage_entry_with_invalid_prev_operation_hash() {
     let (create_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (deactivate_storage_op, _) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::DeactivateStorageEntry(proto::ProtoDeactivateStorageEntry {
-            previous_operation_hash: [0; 32].to_vec(),
-        }),
+        proto::prism::prism_operation::Operation::DeactivateStorageEntry(
+            proto::prism_storage::ProtoDeactivateStorageEntry {
+                previous_operation_hash: [0; 32].to_vec(),
+                special_fields: Default::default(),
+            },
+        ),
     );
 
     let operations = test_utils::populate_metadata(vec![create_did_op, create_storage_op, deactivate_storage_op]);
@@ -315,18 +377,22 @@ fn storage_revoked_after_deactivate_did() {
     let (create_storage_op, create_storage_op_hash) = test_utils::new_signed_operation(
         VDR_KEY_NAME,
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did.suffix.to_vec(),
             nonce: vec![0],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
     let (deactivate_did_op, _) = test_utils::new_signed_operation(
         "master-0",
         &master_sk,
-        proto::prism_operation::Operation::DeactivateDid(proto::ProtoDeactivateDid {
+        proto::prism::prism_operation::Operation::DeactivateDid(proto::prism_ssi::ProtoDeactivateDID {
             previous_operation_hash: create_storage_op_hash.to_vec(),
             id: did.suffix_hex().to_string(),
+            special_fields: Default::default(),
         }),
     );
 
@@ -337,7 +403,7 @@ fn storage_revoked_after_deactivate_did() {
 }
 
 fn create_did_with_vdr_key() -> (
-    proto::SignedPrismOperation,
+    proto::prism::SignedPrismOperation,
     Sha256Digest,
     CanonicalPrismDid,
     Secp256k1PrivateKey,
@@ -347,7 +413,7 @@ fn create_did_with_vdr_key() -> (
     let options = test_utils::CreateDidOptions {
         public_keys: Some(vec![test_utils::new_public_key(
             VDR_KEY_NAME,
-            proto::KeyUsage::VdrKey,
+            proto::prism_ssi::KeyUsage::VDR_KEY,
             &vdr_sk,
         )]),
         ..Default::default()

--- a/lib/did-prism/tests/storage_operation.rs
+++ b/lib/did-prism/tests/storage_operation.rs
@@ -107,8 +107,7 @@ fn update_storage_entry() {
             previous_operation_hash: create_storage_op_hash.to_vec(),
             data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
                 4, 5, 6,
-            ]))
-            .into(),
+            ])),
             special_fields: Default::default(),
         }),
     );

--- a/lib/indexer-storage/Cargo.toml
+++ b/lib/indexer-storage/Cargo.toml
@@ -9,7 +9,7 @@ chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true, features = ["from", "display", "error"] }
 identus-apollo = { workspace = true, features = ["hex"] }
 lazybe = { workspace = true, features = ["postgres"] }
-prost = { workspace = true }
+protobuf = { workspace = true }
 sea-query = { workspace = true, features = [
   "backend-postgres",
   "with-uuid",

--- a/lib/indexer-storage/src/lib.rs
+++ b/lib/indexer-storage/src/lib.rs
@@ -16,7 +16,7 @@ pub enum Error {
     DbMigration { source: sqlx::migrate::MigrateError },
     #[display("unable to decode to protobuf message into type {target_type} from stored data")]
     ProtobufDecode {
-        source: prost::DecodeError,
+        source: protobuf::Error,
         target_type: &'static str,
     },
     #[from]

--- a/lib/indexer-storage/src/pg.rs
+++ b/lib/indexer-storage/src/pg.rs
@@ -1,7 +1,6 @@
 use identus_apollo::hash::Sha256Digest;
 use identus_did_prism::dlt::{BlockMetadata, DltCursor, OperationMetadata};
 use identus_did_prism::prelude::*;
-use identus_did_prism::proto::SignedPrismOperation;
 use identus_did_prism::utils::paging::Paginated;
 use identus_did_prism_indexer::repo::{DltCursorRepo, IndexedOperation, OperationRepo, RawOperationId};
 use lazybe::db::DbOps;

--- a/service/indexer-node/Cargo.toml
+++ b/service/indexer-node/Cargo.toml
@@ -38,5 +38,4 @@ identus-did-prism-indexer = { workspace = true, features = ["oura"] }
 indexer-storage = { workspace = true }
 
 [dev-dependencies]
-prost = { workspace = true }
 identus-did-prism = { workspace = true, features = ["test-utils"] }

--- a/service/indexer-node/examples/seed_data.rs
+++ b/service/indexer-node/examples/seed_data.rs
@@ -25,57 +25,71 @@ async fn main() -> anyhow::Result<()> {
     let (op_1_2, op_hash_1_2) = test_utils::new_signed_operation(
         "vdr-1",
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did_1.suffix.to_vec(),
             nonce: vec![1],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
     let (op_1_3, op_hash_1_3) = test_utils::new_signed_operation(
         "vdr-1",
         &vdr_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: op_hash_1_2.to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![4, 5, 6])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                4, 5, 6,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
     let (op_1_4, _) = test_utils::new_signed_operation(
         "vdr-1",
         &vdr_sk,
-        proto::prism_operation::Operation::UpdateStorageEntry(proto::ProtoUpdateStorageEntry {
+        proto::prism::prism_operation::Operation::UpdateStorageEntry(proto::prism_storage::ProtoUpdateStorageEntry {
             previous_operation_hash: op_hash_1_3.to_vec(),
-            data: Some(proto::proto_update_storage_entry::Data::Bytes(vec![7, 8, 9])),
+            data: Some(proto::prism_storage::proto_update_storage_entry::Data::Bytes(vec![
+                7, 8, 9,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
     let (op_1_5, _) = test_utils::new_signed_operation(
         "vdr-1",
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did_1.suffix.to_vec(),
             nonce: vec![1, 2],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![42])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![42])),
+            special_fields: Default::default(),
         }),
     );
 
     let (op_2_2, op_hash_2_2) = test_utils::new_signed_operation(
         "vdr-2",
         &vdr_sk,
-        proto::prism_operation::Operation::CreateStorageEntry(proto::ProtoCreateStorageEntry {
+        proto::prism::prism_operation::Operation::CreateStorageEntry(proto::prism_storage::ProtoCreateStorageEntry {
             did_prism_hash: did_2.suffix.to_vec(),
             nonce: vec![1],
-            data: Some(proto::proto_create_storage_entry::Data::Bytes(vec![1, 2, 3])),
+            data: Some(proto::prism_storage::proto_create_storage_entry::Data::Bytes(vec![
+                1, 2, 3,
+            ])),
+            special_fields: Default::default(),
         }),
     );
 
     let (op_2_3, _) = test_utils::new_signed_operation(
         "master-0",
         &master_sk,
-        proto::prism_operation::Operation::DeactivateDid(proto::ProtoDeactivateDid {
+        proto::prism::prism_operation::Operation::DeactivateDid(proto::prism_ssi::ProtoDeactivateDID {
             previous_operation_hash: op_hash_2_2.to_vec(),
             id: did_2.suffix_hex().to_string(),
+            special_fields: Default::default(),
         }),
     );
 
@@ -89,11 +103,11 @@ async fn main() -> anyhow::Result<()> {
 fn create_did_with_vdr_key(
     vdr_sk: &Secp256k1PrivateKey,
     vdr_key_name: &str,
-) -> (proto::SignedPrismOperation, Sha256Digest, CanonicalPrismDid) {
+) -> (proto::prism::SignedPrismOperation, Sha256Digest, CanonicalPrismDid) {
     let options = test_utils::CreateDidOptions {
         public_keys: Some(vec![test_utils::new_public_key(
             vdr_key_name,
-            proto::KeyUsage::VdrKey,
+            proto::prism_ssi::KeyUsage::VDR_KEY,
             vdr_sk,
         )]),
         ..Default::default()

--- a/service/indexer-node/src/cli.rs
+++ b/service/indexer-node/src/cli.rs
@@ -28,7 +28,7 @@ pub struct CliArgs {
     #[arg(short, long, default_value_t = 8080)]
     pub port: u16,
     /// The directory containing the web-ui assets (CSS, Javascripts)
-    #[arg(long, default_value = "./indexer-node/assets")]
+    #[arg(long, default_value = "./service/indexer-node/assets")]
     pub assets: PathBuf,
 }
 

--- a/service/indexer-node/src/http/features/ui_resolver/views.rs
+++ b/service/indexer-node/src/http/features/ui_resolver/views.rs
@@ -6,7 +6,7 @@ use identus_did_core::{Did, DidDocument};
 use identus_did_prism::did::operation::{self, PublicKey};
 use identus_did_prism::did::{DidState, PrismDid, PrismDidOps, StorageState};
 use identus_did_prism::dlt::OperationMetadata;
-use identus_did_prism::proto::SignedPrismOperation;
+use identus_did_prism::prelude::SignedPrismOperation;
 use identus_did_prism::protocol::error::ProcessError;
 use identus_did_prism_indexer::dlt::NetworkIdentifier;
 use maud::{Markup, html};


### PR DESCRIPTION
Resolved https://github.com/hyperledger-identus/neoprism/issues/49

`prost` does not preserve protobuf 3 unknown fields. We migrate to `protobuf` which does preserve those fields which is needed for protocol validation correctness.
