### PR TITLE
refactor: split AppState and unify HTTP router struct

### DIFF
--- a/bin/neoprism-node/src/cli.rs
+++ b/bin/neoprism-node/src/cli.rs
@@ -38,8 +38,6 @@ pub struct SubmitterArgs {
     #[clap(flatten)]
     pub server: ServerArgs,
     #[clap(flatten)]
-    pub db: DbArgs,
-    #[clap(flatten)]
     pub dlt_sink: DltSinkArgs,
 }
 

--- a/bin/neoprism-node/src/http/features/api/mod.rs
+++ b/bin/neoprism-node/src/http/features/api/mod.rs
@@ -6,7 +6,7 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::http::features::api::indexer::IndexerOpenApiDoc;
 use crate::http::features::api::submitter::SubmitterOpenApiDoc;
 use crate::http::features::api::system::SystemOpenApiDoc;
-use crate::http::urls;
+use crate::http::{AggregateRouter, urls};
 use crate::{AppState, RunMode};
 
 mod indexer;
@@ -39,7 +39,7 @@ pub fn open_api(mode: &RunMode) -> utoipa::openapi::OpenApi {
     }
 }
 
-pub fn router(mode: RunMode) -> Router<AppState> {
+pub fn router(mode: RunMode) -> AggregateRouter {
     let oas = open_api(&mode);
 
     let base_router = Router::new()
@@ -61,9 +61,9 @@ pub fn router(mode: RunMode) -> Router<AppState> {
         post(submitter::submit_signed_operations),
     );
 
-    match mode {
-        RunMode::Indexer => base_router.merge(indexer_router),
-        RunMode::Submitter => base_router.merge(submitter_router),
-        RunMode::Standalone => base_router.merge(indexer_router).merge(submitter_router),
+    AggregateRouter {
+        app_router: base_router,
+        indexer_router,
+        submitter_router,
     }
 }

--- a/bin/neoprism-node/src/http/features/api/mod.rs
+++ b/bin/neoprism-node/src/http/features/api/mod.rs
@@ -3,11 +3,11 @@ use axum::routing::{get, post};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use crate::RunMode;
 use crate::http::features::api::indexer::IndexerOpenApiDoc;
 use crate::http::features::api::submitter::SubmitterOpenApiDoc;
 use crate::http::features::api::system::SystemOpenApiDoc;
-use crate::http::{AggregateRouter, urls};
-use crate::{AppState, RunMode};
+use crate::http::{Routers, urls};
 
 mod indexer;
 mod submitter;
@@ -39,10 +39,10 @@ pub fn open_api(mode: &RunMode) -> utoipa::openapi::OpenApi {
     }
 }
 
-pub fn router(mode: RunMode) -> AggregateRouter {
+pub fn router(mode: RunMode) -> Routers {
     let oas = open_api(&mode);
 
-    let base_router = Router::new()
+    let app_router = Router::new()
         .merge(SwaggerUi::new(urls::Swagger::AXUM_PATH).url("/api/openapi.json", oas))
         .route(urls::ApiHealth::AXUM_PATH, get(system::health))
         .route(urls::ApiAppMeta::AXUM_PATH, get(system::app_meta));
@@ -61,8 +61,8 @@ pub fn router(mode: RunMode) -> AggregateRouter {
         post(submitter::submit_signed_operations),
     );
 
-    AggregateRouter {
-        app_router: base_router,
+    Routers {
+        app_router,
         indexer_router,
         submitter_router,
     }

--- a/bin/neoprism-node/src/http/features/api/submitter.rs
+++ b/bin/neoprism-node/src/http/features/api/submitter.rs
@@ -3,7 +3,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use utoipa::OpenApi;
 
-use crate::AppState;
+use crate::SubmitterState;
 use crate::http::features::api::submitter::models::{
     SignedOperationSubmissionRequest, SignedOperationSubmissionResponse,
 };
@@ -41,15 +41,11 @@ mod models {
     )
 )]
 pub async fn submit_signed_operations(
-    State(state): State<AppState>,
+    State(state): State<SubmitterState>,
     Json(req): Json<SignedOperationSubmissionRequest>,
 ) -> Result<Json<SignedOperationSubmissionResponse>, StatusCode> {
     let ops = req.signed_operations.into_iter().map(|i| i.into()).collect();
-    let result = state
-        .dlt_sink
-        .expect("DLT sink is not configured for operation submission")
-        .publish_operations(ops)
-        .await;
+    let result = state.dlt_sink.publish_operations(ops).await;
 
     // TODO: improve error handling
     match result {

--- a/bin/neoprism-node/src/http/features/ui_explorer/mod.rs
+++ b/bin/neoprism-node/src/http/features/ui_explorer/mod.rs
@@ -4,20 +4,20 @@ use axum::routing::get;
 use maud::Markup;
 use models::PageQuery;
 
-use crate::AppState;
+use crate::IndexerState;
 use crate::http::urls;
 
 pub(in crate::http) mod models;
 mod views;
 
-pub fn router() -> Router<AppState> {
+pub fn router() -> Router<IndexerState> {
     Router::new()
         .route(urls::Explorer::AXUM_PATH, get(index))
         .route(urls::ExplorerDltCursor::AXUM_PATH, get(dlt_cursor))
         .route(urls::ExplorerDidList::AXUM_PATH, get(did_list))
 }
 
-async fn index(Query(page): Query<PageQuery>, State(state): State<AppState>) -> Markup {
+async fn index(Query(page): Query<PageQuery>, State(state): State<IndexerState>) -> Markup {
     let page = page.page.map(|i| i.max(1) - 1);
     let network = state.dlt_source.as_ref().map(|i| i.network);
     let cursor = state.dlt_source.as_ref().and_then(|i| i.cursor_rx.borrow().to_owned());
@@ -25,12 +25,12 @@ async fn index(Query(page): Query<PageQuery>, State(state): State<AppState>) -> 
     views::index(network, cursor, dids)
 }
 
-async fn dlt_cursor(State(state): State<AppState>) -> Markup {
+async fn dlt_cursor(State(state): State<IndexerState>) -> Markup {
     let cursor = state.dlt_source.as_ref().and_then(|i| i.cursor_rx.borrow().to_owned());
     views::dlt_cursor_card(cursor)
 }
 
-async fn did_list(Query(page): Query<PageQuery>, State(state): State<AppState>) -> Markup {
+async fn did_list(Query(page): Query<PageQuery>, State(state): State<IndexerState>) -> Markup {
     let page = page.page.map(|i| i.max(1) - 1);
     let dids = state.did_service.get_all_dids(page).await.unwrap(); // FIXME: unwrap
     views::did_list(dids)

--- a/bin/neoprism-node/src/http/features/ui_resolver/mod.rs
+++ b/bin/neoprism-node/src/http/features/ui_resolver/mod.rs
@@ -4,17 +4,17 @@ use axum::routing::get;
 use maud::Markup;
 use models::DidQuery;
 
-use crate::AppState;
+use crate::IndexerState;
 use crate::http::urls;
 
 pub(in crate::http) mod models;
 mod views;
 
-pub fn router() -> Router<AppState> {
+pub fn router() -> Router<IndexerState> {
     Router::new().route(urls::Resolver::AXUM_PATH, get(index))
 }
 
-async fn index(Query(query): Query<DidQuery>, State(state): State<AppState>) -> Markup {
+async fn index(Query(query): Query<DidQuery>, State(state): State<IndexerState>) -> Markup {
     let network = state.dlt_source.map(|i| i.network);
     match query.did.as_ref() {
         None => views::index(network),

--- a/bin/neoprism-node/src/http/mod.rs
+++ b/bin/neoprism-node/src/http/mod.rs
@@ -6,7 +6,7 @@ use axum::routing::get;
 use features::{api, ui_explorer, ui_resolver};
 use tower_http::services::ServeDir;
 
-use crate::{AppState, RunMode};
+use crate::{AppState, IndexerState, RunMode, SubmitterState};
 
 mod components;
 mod features;
@@ -14,7 +14,13 @@ mod urls;
 
 pub use features::api::open_api;
 
-pub fn router(assets_dir: &Path, mode: RunMode) -> Router<AppState> {
+pub struct AggregateRouter {
+    app_router: Router<AppState>,
+    indexer_router: Router<IndexerState>,
+    submitter_router: Router<SubmitterState>,
+}
+
+pub fn router(assets_dir: &Path, mode: RunMode) -> AggregateRouter {
     tracing::info!("Serving static asset from {:?}", assets_dir);
 
     let api_router = api::router(mode);

--- a/bin/neoprism-node/src/lib.rs
+++ b/bin/neoprism-node/src/lib.rs
@@ -114,7 +114,7 @@ async fn run_submitter_command(args: SubmitterArgs) -> anyhow::Result<()> {
     let app_state = AppState {
         run_mode: RunMode::Submitter,
     };
-    let submitter_state = SubmitterState { dlt_sink: dlt_sink };
+    let submitter_state = SubmitterState { dlt_sink };
     run_server(app_state, None, Some(submitter_state), &args.server).await
 }
 
@@ -131,7 +131,7 @@ async fn run_standalone_command(args: StandaloneArgs) -> anyhow::Result<()> {
         did_service: DidService::new(&db),
         dlt_source: cursor_rx.map(|cursor_rx| DltSourceState { cursor_rx, network }),
     };
-    let submitter_state = SubmitterState { dlt_sink: dlt_sink };
+    let submitter_state = SubmitterState { dlt_sink };
     run_server(app_state, Some(indexer_state), Some(submitter_state), &args.server).await
 }
 

--- a/bin/neoprism-node/src/lib.rs
+++ b/bin/neoprism-node/src/lib.rs
@@ -38,11 +38,19 @@ enum RunMode {
 
 #[derive(Clone)]
 struct AppState {
+    run_mode: RunMode,
+}
+
+#[derive(Clone)]
+struct IndexerState {
     pg_pool: PgPool,
     did_service: DidService,
     dlt_source: Option<DltSourceState>,
-    dlt_sink: Option<Arc<dyn DltSink>>,
-    run_mode: RunMode,
+}
+
+#[derive(Clone)]
+struct SubmitterState {
+    dlt_sink: Arc<dyn DltSink>,
 }
 
 #[derive(Clone)]
@@ -51,7 +59,7 @@ struct DltSourceState {
     network: NetworkIdentifier,
 }
 
-impl RouteConfig for AppState {
+impl RouteConfig for IndexerState {
     type Ctx = PostgresDbCtx;
     type Db = Postgres;
 
@@ -90,26 +98,23 @@ async fn run_indexer_command(args: IndexerArgs) -> anyhow::Result<()> {
     let network = args.dlt_source.cardano_network.clone().into();
     let cursor_rx = init_dlt_source(&args.dlt_source, &network, &db).await;
     let app_state = AppState {
-        pg_pool: db.pool.clone(),
         run_mode: RunMode::Indexer,
+    };
+    let indexer_state = IndexerState {
+        pg_pool: db.pool.clone(),
         did_service: DidService::new(&db),
         dlt_source: cursor_rx.map(|cursor_rx| DltSourceState { cursor_rx, network }),
-        dlt_sink: None,
     };
-    run_server(app_state, &args.server).await
+    run_server(app_state, Some(indexer_state), None, &args.server).await
 }
 
 async fn run_submitter_command(args: SubmitterArgs) -> anyhow::Result<()> {
-    let db = init_database(&args.db).await;
     let dlt_sink = init_dlt_sink(&args.dlt_sink);
     let app_state = AppState {
-        pg_pool: db.pool.clone(),
         run_mode: RunMode::Submitter,
-        did_service: DidService::new(&db),
-        dlt_source: None,
-        dlt_sink: Some(dlt_sink),
     };
-    run_server(app_state, &args.server).await
+    let submitter_state = SubmitterState { dlt_sink: dlt_sink };
+    run_server(app_state, None, Some(submitter_state), &args.server).await
 }
 
 async fn run_standalone_command(args: StandaloneArgs) -> anyhow::Result<()> {
@@ -118,16 +123,23 @@ async fn run_standalone_command(args: StandaloneArgs) -> anyhow::Result<()> {
     let cursor_rx = init_dlt_source(&args.dlt_source, &network, &db).await;
     let dlt_sink = init_dlt_sink(&args.dlt_sink);
     let app_state = AppState {
-        pg_pool: db.pool.clone(),
         run_mode: RunMode::Standalone,
+    };
+    let indexer_state = IndexerState {
+        pg_pool: db.pool.clone(),
         did_service: DidService::new(&db),
         dlt_source: cursor_rx.map(|cursor_rx| DltSourceState { cursor_rx, network }),
-        dlt_sink: Some(dlt_sink),
     };
-    run_server(app_state, &args.server).await
+    let submitter_state = SubmitterState { dlt_sink: dlt_sink };
+    run_server(app_state, Some(indexer_state), Some(submitter_state), &args.server).await
 }
 
-async fn run_server(app_state: AppState, server_args: &ServerArgs) -> anyhow::Result<()> {
+async fn run_server(
+    app_state: AppState,
+    indexer_state: Option<IndexerState>,
+    submitter_state: Option<SubmitterState>,
+    server_args: &ServerArgs,
+) -> anyhow::Result<()> {
     let layer = ServiceBuilder::new()
         .layer(TraceLayer::new_for_http())
         .option_layer(Some(CorsLayer::permissive()).filter(|_| server_args.cors_enabled));


### PR DESCRIPTION
Split AppState into focused states and unify HTTP router construction.
This clarifies responsibilities, makes state injection explicit, and simplifies mode-specific deployment.

- Break AppState into AppState (run_mode), IndexerState (pg_pool, did_service, optional dlt_source), and SubmitterState (dlt_sink).
- Introduce a Routers struct (app_router, indexer_router, submitter_router) and have the OpenAPI/router module return structured routers.
- Mount routers conditionally at startup based on run mode (Indexer, Submitter, Standalone).
- Remove the DB dependency from the submitter command and simplify submitter submission flow.

