### PR TITLE
docs: add mnemonic warnings, semaphore comment, and fix subprocess wording

### DIFF
--- a/docker/prism-test/README.md
+++ b/docker/prism-test/README.md
@@ -129,6 +129,8 @@ The local Cardano testnet is configured with custom parameters for testing.
 
 ### Wallet
 
+> ⚠️ **WARNING:** The mnemonic below is for testing purposes only. Never use this mnemonic on mainnet or any network with real funds. Anyone with access to this mnemonic can control the associated funds.
+
 A pre-configured wallet is available on the **cardano-wallet** service for testing purposes.
 
 | Property | Value |

--- a/docs/src/configuration/submitter.md
+++ b/docs/src/configuration/submitter.md
@@ -66,7 +66,7 @@ The traditional approach that requires a full Cardano wallet service running alo
 
 **Embedded Wallet**
 
-A lightweight alternative that eliminates the need for an external wallet service. It uses a companion binary to construct and sign transactions in-process. By default, transactions are submitted via Blockfrost; a Cardano Submit API endpoint can be configured as an alternative. This is the recommended option for most deployments due to its simpler operational model.
+A lightweight alternative that eliminates the need for an external wallet service. It uses a companion binary to construct and sign transactions as a subprocess. By default, transactions are submitted via Blockfrost; a Cardano Submit API endpoint can be configured as an alternative. This is the recommended option for most deployments due to its simpler operational model.
 
 ---
 

--- a/lib/did-prism-submitter/src/dlt/embedded_wallet.rs
+++ b/lib/did-prism-submitter/src/dlt/embedded_wallet.rs
@@ -85,6 +85,9 @@ impl EmbeddedWalletSink {
         Self {
             config,
             client: Client::new(),
+            // Semaphore limits concurrency to 1 because all transactions share a single
+            // UTXO set — concurrent submissions would encounter UTXO contention
+            // (double-spending the same inputs). Serializing submissions avoids this.
             semaphore: Semaphore::new(1),
         }
     }

--- a/tools/compose_gen/stacks/prism_test.py
+++ b/tools/compose_gen/stacks/prism_test.py
@@ -52,7 +52,7 @@ def mk_stack(options: Options | None = None) -> ComposeConfig:
     wallet_id = "9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d"
     wallet_passphrase = "super_secret"
     wallet_payment_address = "addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3"  # noqa: E501
-    wallet_mnemonic = "mimic candy diamond virus hospital dragon culture price emotion tell update give faint resist faculty soup demand window dignity capital bullet purity practice fossil"  # noqa: E501
+    wallet_mnemonic = "mimic candy diamond virus hospital dragon culture price emotion tell update give faint resist faculty soup demand window dignity capital bullet purity practice fossil"  # WARNING: Test-only mnemonic. Never use on mainnet.  # noqa: E501
 
     # Blockfrost services
     bf_services = {


### PR DESCRIPTION
Minor fixes from PR #245 review feedback. Addresses review points 1, 7, and 8.

## Changes

### Point 1: Mnemonic exposed in Docker Compose environment variables
The mnemonic is hardcoded in the compose file as an environment variable. While this is a CI test compose, the mnemonic is visible in plaintext. Added warnings that this mnemonic should never be used on mainnet.

- Added ⚠️ WARNING in `docker/prism-test/README.md` Wallet section stating the mnemonic is test-only and must never be used on mainnet or any network with real funds
- Added `# WARNING: Test-only mnemonic. Never use on mainnet.` comment next to the `wallet_mnemonic` variable in `tools/compose_gen/stacks/prism_test.py`
- Note: Auto-generated compose YAML files were intentionally left untouched since they carry a `# Code generated by Python script. DO NOT EDIT.` header

### Point 7: Semaphore serializes all submissions — document the design choice
`Semaphore::new(1)` in `lib/did-prism-submitter/src/dlt/embedded_wallet.rs` means only one transaction can be built/submitted at a time. This is intentional due to UTXO contention. Added a code comment explaining this design choice so future readers understand why concurrency is limited to 1.

### Point 8: Docs say "in-process" but embedded wallet runs as a subprocess
`docs/src/configuration/submitter.md` said the embedded wallet "sign and submit transactions in-process" but it actually spawns a Bun-compiled TypeScript binary as a subprocess. Fixed the wording to say "as a subprocess" to accurately describe the architecture.

## Review Context
- https://github.com/hyperledger-identus/neoprism/pull/245#pullrequestreview-2376505278

All changes are documentation/comment-only — no behavioral code changes.