### PR TITLE
feat: add --embedded-wallet-mnemonic-file CLI flag for file-based secret loading

### DIFF
--- a/bin/neoprism-node/src/cli.rs
+++ b/bin/neoprism-node/src/cli.rs
@@ -235,8 +235,15 @@ pub struct EmbeddedWalletArgs {
     #[arg(long, env = "NPRISM_EMBEDDED_WALLET_BLOCKFROST_API_KEY")]
     pub embedded_wallet_blockfrost_api_key: Option<String>,
     /// Mnemonic phrase for the embedded wallet. Required when --dlt-sink-type=embedded-wallet.
+    /// Mutually exclusive with --embedded-wallet-mnemonic-file.
     #[arg(long, env = "NPRISM_EMBEDDED_WALLET_MNEMONIC")]
     pub embedded_wallet_mnemonic: Option<String>,
+    /// Path to a file containing the mnemonic phrase for the embedded wallet.
+    /// A safer alternative to --embedded-wallet-mnemonic for production deployments.
+    /// The file contents are trimmed of leading/trailing whitespace.
+    /// Mutually exclusive with --embedded-wallet-mnemonic.
+    #[arg(long, env = "NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE")]
+    pub embedded_wallet_mnemonic_file: Option<PathBuf>,
 }
 
 #[derive(Args)]

--- a/bin/neoprism-node/src/lib.rs
+++ b/bin/neoprism-node/src/lib.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use app::service::PrismDidService;
 use axum::Router;
 use clap::Parser;
@@ -154,7 +155,7 @@ async fn run_indexer_command(args: IndexerArgs) -> anyhow::Result<()> {
 
 async fn run_submitter_command(args: SubmitterArgs) -> anyhow::Result<()> {
     let network: NetworkIdentifier = args.network.cardano_network.clone().into();
-    let dlt_sink = init_dlt_sink(&args.dlt_sink, &network);
+    let dlt_sink = init_dlt_sink(&args.dlt_sink, &network)?;
     let app_state = AppState {
         run_mode: RunMode::Submitter,
     };
@@ -166,7 +167,7 @@ async fn run_standalone_command(args: StandaloneArgs) -> anyhow::Result<()> {
     let network = args.dlt_source.network.cardano_network.clone().into();
     let db = init_database(&args.db, Some(&network)).await;
     let (cursor_rx, mut handles) = init_dlt_source(&args.dlt_source, &network, db.clone()).await;
-    let dlt_sink = init_dlt_sink(&args.dlt_sink, &network);
+    let dlt_sink = init_dlt_sink(&args.dlt_sink, &network)?;
     let app_state = AppState {
         run_mode: RunMode::Standalone,
     };
@@ -420,7 +421,35 @@ async fn init_dlt_source(dlt_args: &DltSourceArgs, network: &NetworkIdentifier, 
     }
 }
 
-fn init_dlt_sink(dlt_args: &DltSinkArgs, network: &NetworkIdentifier) -> Arc<dyn DltSink + Send + Sync> {
+/// Resolves the mnemonic from either a direct value or a file path.
+///
+/// Returns an error if both sources are provided (mutually exclusive)
+/// or if neither is provided.
+fn resolve_mnemonic(mnemonic_value: Option<&str>, mnemonic_file: Option<&Path>) -> anyhow::Result<String> {
+    match (mnemonic_value, mnemonic_file) {
+        (Some(_), Some(_)) => {
+            anyhow::bail!(
+                "--embedded-wallet-mnemonic and --embedded-wallet-mnemonic-file are mutually exclusive; provide only one"
+            );
+        }
+        (Some(value), None) => Ok(value.to_string()),
+        (None, Some(path)) => {
+            let content =
+                fs::read_to_string(path).with_context(|| format!("failed to read mnemonic file {}", path.display()))?;
+            Ok(content.trim().to_string())
+        }
+        (None, None) => {
+            anyhow::bail!(
+                "either --embedded-wallet-mnemonic or --embedded-wallet-mnemonic-file is required when --dlt-sink-type=embedded-wallet"
+            );
+        }
+    }
+}
+
+fn init_dlt_sink(
+    dlt_args: &DltSinkArgs,
+    network: &NetworkIdentifier,
+) -> anyhow::Result<Arc<dyn DltSink + Send + Sync>> {
     match dlt_args.dlt_sink_type {
         DltSinkType::CardanoWallet => {
             let cardano_wallet_url = dlt_args
@@ -447,12 +476,12 @@ fn init_dlt_sink(dlt_args: &DltSinkArgs, network: &NetworkIdentifier) -> Arc<dyn
                 .clone()
                 .expect("--cardano-wallet-payment-addr is required when --dlt-sink-type=cardano-wallet");
 
-            Arc::new(CardanoWalletSink::new(
+            Ok(Arc::new(CardanoWalletSink::new(
                 cardano_wallet_url,
                 cardano_wallet_wallet_id,
                 cardano_wallet_passphrase,
                 cardano_wallet_payment_addr,
-            ))
+            )))
         }
         DltSinkType::EmbeddedWallet => {
             use identus_did_prism_submitter::dlt::embedded_wallet::{
@@ -475,11 +504,10 @@ fn init_dlt_sink(dlt_args: &DltSinkArgs, network: &NetworkIdentifier) -> Arc<dyn
                 .clone()
                 .filter(|s| !s.is_empty());
 
-            let mnemonic = dlt_args
-                .embedded_wallet
-                .embedded_wallet_mnemonic
-                .clone()
-                .expect("--embedded-wallet-mnemonic is required when --dlt-sink-type=embedded-wallet");
+            let mnemonic = resolve_mnemonic(
+                dlt_args.embedded_wallet.embedded_wallet_mnemonic.as_deref(),
+                dlt_args.embedded_wallet.embedded_wallet_mnemonic_file.as_deref(),
+            )?;
 
             let network = match network {
                 NetworkIdentifier::Mainnet => Network::Mainnet,
@@ -497,7 +525,7 @@ fn init_dlt_sink(dlt_args: &DltSinkArgs, network: &NetworkIdentifier) -> Arc<dyn
                 mnemonic: Arc::from(mnemonic),
             };
 
-            Arc::new(EmbeddedWalletSink::new(config))
+            Ok(Arc::new(EmbeddedWalletSink::new(config)))
         }
     }
 }
@@ -732,5 +760,60 @@ mod tests {
     fn prepare_sqlite_destination_is_noop_for_non_sqlite_url() {
         // Should succeed without touching the filesystem.
         prepare_sqlite_destination("postgres://localhost/test").unwrap();
+    }
+
+    // --- resolve_mnemonic ---
+
+    #[test]
+    fn resolve_mnemonic_from_direct_value() {
+        let result = resolve_mnemonic(Some("word1 word2 word3"), None);
+        assert_eq!(result.unwrap(), "word1 word2 word3");
+    }
+
+    #[test]
+    fn resolve_mnemonic_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("mnemonic.txt");
+        fs::write(&file_path, "word1 word2 word3\n").unwrap();
+        let result = resolve_mnemonic(None, Some(&file_path));
+        assert_eq!(result.unwrap(), "word1 word2 word3");
+    }
+
+    #[test]
+    fn resolve_mnemonic_from_file_trims_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("mnemonic.txt");
+        fs::write(&file_path, "  word1 word2 word3  \n\n").unwrap();
+        let result = resolve_mnemonic(None, Some(&file_path));
+        assert_eq!(result.unwrap(), "word1 word2 word3");
+    }
+
+    #[test]
+    fn resolve_mnemonic_conflict_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("mnemonic.txt");
+        fs::write(&file_path, "word1 word2\n").unwrap();
+        let result = resolve_mnemonic(Some("direct mnemonic"), Some(&file_path));
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "expected mutual-exclusion error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_mnemonic_neither_provided_returns_error() {
+        let result = resolve_mnemonic(None::<&str>, None::<&Path>);
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("required"),
+            "expected required-error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_mnemonic_missing_file_returns_error() {
+        let result = resolve_mnemonic(None, Some(Path::new("/nonexistent/mnemonic.txt")));
+        assert!(result.is_err(), "expected error for missing file");
     }
 }

--- a/docker/prism-test/README.md
+++ b/docker/prism-test/README.md
@@ -100,6 +100,10 @@ Lightweight setup with only NeoPRISM standalone service running in dev mode. Use
 
 CI testing stack that uses the embedded wallet submitter instead of cardano-wallet service. Uses locally built `identus-neoprism:latest` image with PostgreSQL backend and Blockfrost DLT source. Tests the embedded wallet transaction submission path without a running wallet service. The embedded-wallet binary must be present in the Docker image at `/bin/embedded-wallet`.
 
+The mnemonic is loaded from the `mnemonic.txt` file via a read-only bind mount, rather than being passed as an environment variable. This mimics the recommended production pattern of using `--embedded-wallet-mnemonic-file` with a Docker/Kubernetes secret mount.
+
+> ⚠️ **WARNING:** The `mnemonic.txt` file contains a test-only mnemonic. Never use this mnemonic on mainnet or any network with real funds.
+
 | Service | Port | Description |
 |---------|------|-------------|
 | **neoprism-standalone** | 18080 | NeoPRISM HTTP API (PostgreSQL backend, embedded-wallet submitter) |

--- a/docker/prism-test/README.md
+++ b/docker/prism-test/README.md
@@ -102,8 +102,6 @@ CI testing stack that uses the embedded wallet submitter instead of cardano-wall
 
 The mnemonic is loaded from the `mnemonic.txt` file via a read-only bind mount, rather than being passed as an environment variable. This mimics the recommended production pattern of using `--embedded-wallet-mnemonic-file` with a Docker/Kubernetes secret mount.
 
-> ⚠️ **WARNING:** The `mnemonic.txt` file contains a test-only mnemonic. Never use this mnemonic on mainnet or any network with real funds.
-
 | Service | Port | Description |
 |---------|------|-------------|
 | **neoprism-standalone** | 18080 | NeoPRISM HTTP API (PostgreSQL backend, embedded-wallet submitter) |

--- a/docker/prism-test/compose-ci-embedded-wallet.yml
+++ b/docker/prism-test/compose-ci-embedded-wallet.yml
@@ -189,9 +189,7 @@ services:
       NPRISM_DLT_SOURCE_TYPE: blockfrost
       NPRISM_EMBEDDED_WALLET_BLOCKFROST_API_KEY: ''
       NPRISM_EMBEDDED_WALLET_BLOCKFROST_URL: http://bf-proxy:3000
-      NPRISM_EMBEDDED_WALLET_MNEMONIC: mimic candy diamond virus hospital dragon culture
-        price emotion tell update give faint resist faculty soup demand window dignity
-        capital bullet purity practice fossil
+      NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE: /run/secrets/mnemonic
       NPRISM_EMBEDDED_WALLET_SUBMIT_API_URL: http://cardano-submit-api:8090
       NPRISM_EXTERNAL_URL: http://localhost:18080
       NPRISM_INDEX_INTERVAL: 1s
@@ -209,5 +207,7 @@ services:
     ports:
     - 18080:8080
     restart: always
+    volumes:
+    - ./mnemonic.txt:/run/secrets/mnemonic:ro
 volumes:
   node-testnet: {}

--- a/docker/prism-test/mnemonic.txt
+++ b/docker/prism-test/mnemonic.txt
@@ -1,0 +1,1 @@
+mimic candy diamond virus hospital dragon culture price emotion tell update give faint resist faculty soup demand window dignity capital bullet purity practice fossil

--- a/docs/src/configuration/submitter.md
+++ b/docs/src/configuration/submitter.md
@@ -47,7 +47,8 @@ Transactions are submitted via a **Cardano Submit API** endpoint (`--embedded-wa
 | Flag | Environment Variable | Description |
 |------|---------------------|-------------|
 | `--embedded-wallet-bin` | `NPRISM_EMBEDDED_WALLET_BIN` | Path to the embedded wallet binary |
-| `--embedded-wallet-mnemonic` | `NPRISM_EMBEDDED_WALLET_MNEMONIC` | Mnemonic phrase for the wallet |
+| `--embedded-wallet-mnemonic` | `NPRISM_EMBEDDED_WALLET_MNEMONIC` | Mnemonic phrase for the wallet (mutually exclusive with `--embedded-wallet-mnemonic-file`) |
+| `--embedded-wallet-mnemonic-file` | `NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE` | Path to a file containing the mnemonic phrase (mutually exclusive with `--embedded-wallet-mnemonic`) |
 | `--embedded-wallet-submit-api-url` | `NPRISM_EMBEDDED_WALLET_SUBMIT_API_URL` | Cardano Submit API URL (omit to submit via Blockfrost) |
 | `--embedded-wallet-blockfrost-url` | `NPRISM_EMBEDDED_WALLET_BLOCKFROST_URL` | Blockfrost API URL for private instances (default: `https://cardano-mainnet.blockfrost.io/api/v0`) |
 | `--embedded-wallet-blockfrost-api-key` | `NPRISM_EMBEDDED_WALLET_BLOCKFROST_API_KEY` | Blockfrost API key for public instances (takes precedence over `--embedded-wallet-blockfrost-url` when set) |
@@ -55,6 +56,8 @@ Transactions are submitted via a **Cardano Submit API** endpoint (`--embedded-wa
 > **Note:** When `--embedded-wallet-blockfrost-api-key` is set, it takes precedence over `--embedded-wallet-blockfrost-url` for Blockfrost requests. The submitter uses the default public Blockfrost URL for both UTXO resolution and submission in this case. To submit via a Cardano Submit API endpoint instead of Blockfrost, set `--embedded-wallet-submit-api-url`.
 
 > **Note:** For network parameters (mainnet, preprod, etc.), use the shared `--cardano-network` flag documented in the [Indexer configuration](./indexer.md).
+
+> **Security recommendation:** Prefer `--embedded-wallet-mnemonic-file` over `--embedded-wallet-mnemonic` in production deployments. Environment variables can leak via `/proc/<pid>/environ`, process listings, crash dumps, or log output. Loading the mnemonic from a file allows you to restrict file permissions (e.g., `chmod 600`) and use container secret mounts (Docker/Kubernetes secrets). Supplying both flags simultaneously is treated as a configuration error and will prevent the node from starting.
 
 ---
 

--- a/tools/compose_gen/services/neoprism.py
+++ b/tools/compose_gen/services/neoprism.py
@@ -104,22 +104,47 @@ class Options(BaseModel):
 def mk_service(options: Options) -> Service:
     image = options.image_override or f"hyperledgeridentus/identus-neoprism:{VERSION}"
 
-    # Build environment variables
-    environment = {
-        "RUST_LOG": "info,oura=warn,tracing::span=warn",
-        "NPRISM_CARDANO_NETWORK": options.network,
-    }
+    return Service(
+        image=image,
+        ports=[f"{options.host_port}:8080"] if options.host_port else None,
+        environment=_add_environment(options),
+        command=[options.command.command],
+        depends_on=_add_depends_on(options),
+        healthcheck=Healthcheck(
+            test=["CMD", "curl", "-f", "http://localhost:8080/api/_system/health"]
+        ),
+        volumes=_add_volumes(options),
+    )
+
+
+def _add_depends_on(options: Options) -> dict[str, ServiceDependency] | None:
+    """Build service dependencies based on storage backend and DLT sink."""
     depends_on: dict[str, ServiceDependency] = {}
 
-    if isinstance(options.storage_backend, SqliteStorageBackend):
-        environment["NPRISM_DB_URL"] = options.storage_backend.db_url
-    else:
-        environment["NPRISM_DB_URL"] = options.storage_backend.db_url
+    if isinstance(options.storage_backend, PostgresStorageBackend):
         depends_on[options.storage_backend.host] = ServiceDependency(
             condition="service_healthy"
         )
 
-    # Add optional configuration
+    if isinstance(options.command, StandaloneCommand) and isinstance(
+        options.command.dlt_sink, CardanoWalletSink
+    ):
+        depends_on[options.command.dlt_sink.wallet_host] = ServiceDependency(
+            condition="service_healthy"
+        )
+
+    return depends_on or None
+
+
+def _add_environment(options: Options) -> dict[str, str]:
+    """Build environment variables for the neoprism service."""
+    environment = {
+        "RUST_LOG": "info,oura=warn,tracing::span=warn",
+        "NPRISM_CARDANO_NETWORK": options.network,
+        "NPRISM_DB_URL": options.storage_backend.db_url,
+    }
+
+    # Optional configuration
     if options.confirmation_blocks is not None:
         environment["NPRISM_CONFIRMATION_BLOCKS"] = str(options.confirmation_blocks)
 
@@ -136,42 +161,24 @@ def mk_service(options: Options) -> Service:
     # DLT sink - only standalone needs this
     if isinstance(options.command, StandaloneCommand):
         _add_dlt_sink_env(environment, options.command.dlt_sink)
-        if isinstance(options.command.dlt_sink, CardanoWalletSink):
-            # CardanoWalletSink requires wallet service to be healthy
-            depends_on[options.command.dlt_sink.wallet_host] = ServiceDependency(
-                condition="service_healthy"
-            )
 
-    # Determine command based on mode
-    command = [options.command.command]
+    return environment
 
-    # Build ports
-    ports = [f"{options.host_port}:8080"] if options.host_port else None
 
-    # Build volumes
+def _add_volumes(options: Options) -> list[str] | None:
+    """Build volume mounts, including mnemonic file for embedded wallet."""
     volumes = list(options.volumes or [])
+
     if (
         isinstance(options.command, StandaloneCommand)
         and isinstance(options.command.dlt_sink, EmbeddedWalletSink)
         and options.command.dlt_sink.mnemonic_file
     ):
-        # Mount mnemonic file as read-only volume into the container
-        mnemonic_host_path = options.command.dlt_sink.mnemonic_file
-        volumes.append(f"{mnemonic_host_path}:/run/secrets/mnemonic:ro")
-        # Override the container path in environment
-        environment["NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE"] = "/run/secrets/mnemonic"
+        volumes.append(
+            f"{options.command.dlt_sink.mnemonic_file}:/run/secrets/mnemonic:ro"
+        )
 
-    return Service(
-        image=image,
-        ports=ports,
-        environment=environment,
-        command=command,
-        depends_on=depends_on or None,
-        healthcheck=Healthcheck(
-            test=["CMD", "curl", "-f", "http://localhost:8080/api/_system/health"]
-        ),
-        volumes=volumes or None,
-    )
+    return volumes or None
 
 
 def _add_dlt_source_env(
@@ -215,5 +222,5 @@ def _add_dlt_sink_env(env: dict[str, str], sink: DltSink) -> None:
         env["NPRISM_EMBEDDED_WALLET_BLOCKFROST_API_KEY"] = sink.blockfrost_api_key
         if sink.mnemonic is not None:
             env["NPRISM_EMBEDDED_WALLET_MNEMONIC"] = sink.mnemonic
-        # When mnemonic_file is set, the container path is set by mk_service
-        # after the volume mount is configured.
+        if sink.mnemonic_file is not None:
+            env["NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE"] = "/run/secrets/mnemonic"

--- a/tools/compose_gen/services/neoprism.py
+++ b/tools/compose_gen/services/neoprism.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from ..metadata import VERSION
 from ..models import Healthcheck, Service, ServiceDependency
@@ -38,7 +38,21 @@ class EmbeddedWalletSink(BaseModel):
     submit_api_url: str
     blockfrost_url: str
     blockfrost_api_key: str
-    mnemonic: str
+    mnemonic: str | None = None
+    mnemonic_file: str | None = None
+
+    @model_validator(mode="after")
+    def validate_mnemonic_config(self) -> "EmbeddedWalletSink":
+        if self.mnemonic is not None and self.mnemonic_file is not None:
+            raise ValueError(
+                "EmbeddedWalletSink: 'mnemonic' and 'mnemonic_file'"
+                " are mutually exclusive"
+            )
+        if self.mnemonic is None and self.mnemonic_file is None:
+            raise ValueError(
+                "EmbeddedWalletSink: either 'mnemonic' or 'mnemonic_file' is required"
+            )
+        return self
 
 
 DltSink = CardanoWalletSink | EmbeddedWalletSink
@@ -134,6 +148,19 @@ def mk_service(options: Options) -> Service:
     # Build ports
     ports = [f"{options.host_port}:8080"] if options.host_port else None
 
+    # Build volumes
+    volumes = list(options.volumes or [])
+    if (
+        isinstance(options.command, StandaloneCommand)
+        and isinstance(options.command.dlt_sink, EmbeddedWalletSink)
+        and options.command.dlt_sink.mnemonic_file
+    ):
+        # Mount mnemonic file as read-only volume into the container
+        mnemonic_host_path = options.command.dlt_sink.mnemonic_file
+        volumes.append(f"{mnemonic_host_path}:/run/secrets/mnemonic:ro")
+        # Override the container path in environment
+        environment["NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE"] = "/run/secrets/mnemonic"
+
     return Service(
         image=image,
         ports=ports,
@@ -143,7 +170,7 @@ def mk_service(options: Options) -> Service:
         healthcheck=Healthcheck(
             test=["CMD", "curl", "-f", "http://localhost:8080/api/_system/health"]
         ),
-        volumes=options.volumes,
+        volumes=volumes or None,
     )
 
 
@@ -186,4 +213,7 @@ def _add_dlt_sink_env(env: dict[str, str], sink: DltSink) -> None:
         env["NPRISM_EMBEDDED_WALLET_SUBMIT_API_URL"] = sink.submit_api_url
         env["NPRISM_EMBEDDED_WALLET_BLOCKFROST_URL"] = sink.blockfrost_url
         env["NPRISM_EMBEDDED_WALLET_BLOCKFROST_API_KEY"] = sink.blockfrost_api_key
-        env["NPRISM_EMBEDDED_WALLET_MNEMONIC"] = sink.mnemonic
+        if sink.mnemonic is not None:
+            env["NPRISM_EMBEDDED_WALLET_MNEMONIC"] = sink.mnemonic
+        # When mnemonic_file is set, the container path is set by mk_service
+        # after the volume mount is configured.

--- a/tools/compose_gen/stacks/prism_test.py
+++ b/tools/compose_gen/stacks/prism_test.py
@@ -52,7 +52,6 @@ def mk_stack(options: Options | None = None) -> ComposeConfig:
     wallet_id = "9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d"
     wallet_passphrase = "super_secret"
     wallet_payment_address = "addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3"  # noqa: E501
-    wallet_mnemonic = "mimic candy diamond virus hospital dragon culture price emotion tell update give faint resist faculty soup demand window dignity capital bullet purity practice fossil"  # WARNING: Test-only mnemonic. Never use on mainnet.  # noqa: E501
 
     # Blockfrost services
     bf_services = {
@@ -132,7 +131,7 @@ def mk_stack(options: Options | None = None) -> ComposeConfig:
                 submit_api_url="http://cardano-submit-api:8090",
                 blockfrost_url="http://bf-proxy:3000",
                 blockfrost_api_key="",
-                mnemonic=wallet_mnemonic,
+                mnemonic_file="./mnemonic.txt",
             )
         )
     else:


### PR DESCRIPTION
## Summary

Addresses review point 2 from PR #245 ([review comment](https://github.com/hyperledger-identus/neoprism/pull/245#pullrequestreview-2376505278)).

The embedded wallet currently accepts its mnemonic only via an environment variable (`NPRISM_EMBEDDED_WALLET_MNEMONIC`). Environment variables can leak through `/proc/<pid>/environ`, process listings, crash dumps, and log output — a security concern for production deployments.

This PR adds `--embedded-wallet-mnemonic-file` / `NPRISM_EMBEDDED_WALLET_MNEMONIC_FILE` as a mutually exclusive alternative that reads the mnemonic from a file at runtime. This enables users to store the mnemonic as a Docker/Kubernetes secret mounted as a file, restrict access via file permissions, and avoid exposing it in the process environment. Providing both the direct value and the file-based option simultaneously is treated as a configuration error and prevents the node from starting.

The file-based option is now the recommended pattern — the `prism-test` Docker compose stack has been updated to mount `mnemonic.txt` read-only instead of passing the mnemonic as an env var, and the configuration docs include a security recommendation favouring the file-based approach in production.