### PR TITLE
fix: revert cardano-wallet URL naming to use base-url consistently

### DIFF
--- a/bin/neoprism-node/src/cli.rs
+++ b/bin/neoprism-node/src/cli.rs
@@ -202,8 +202,8 @@ pub enum DltSinkType {
 #[command(next_help_heading = "Cardano Wallet")]
 pub struct CardanoWalletArgs {
     /// Base URL of the Cardano wallet. Required when --dlt-sink-type=cardano-wallet.
-    #[arg(long, env = "NPRISM_CARDANO_WALLET_URL")]
-    pub cardano_wallet_url: Option<String>,
+    #[arg(long, env = "NPRISM_CARDANO_WALLET_BASE_URL")]
+    pub cardano_wallet_base_url: Option<String>,
     /// Wallet ID to use for making transactions. Required when --dlt-sink-type=cardano-wallet.
     #[arg(long, env = "NPRISM_CARDANO_WALLET_WALLET_ID")]
     pub cardano_wallet_wallet_id: Option<String>,

--- a/bin/neoprism-node/src/lib.rs
+++ b/bin/neoprism-node/src/lib.rs
@@ -452,11 +452,11 @@ fn init_dlt_sink(
 ) -> anyhow::Result<Arc<dyn DltSink + Send + Sync>> {
     match dlt_args.dlt_sink_type {
         DltSinkType::CardanoWallet => {
-            let cardano_wallet_url = dlt_args
+            let cardano_wallet_base_url = dlt_args
                 .cardano_wallet
-                .cardano_wallet_url
+                .cardano_wallet_base_url
                 .clone()
-                .expect("--cardano-wallet-url is required when --dlt-sink-type=cardano-wallet");
+                .expect("--cardano-wallet-base-url is required when --dlt-sink-type=cardano-wallet");
 
             let cardano_wallet_wallet_id = dlt_args
                 .cardano_wallet
@@ -477,7 +477,7 @@ fn init_dlt_sink(
                 .expect("--cardano-wallet-payment-addr is required when --dlt-sink-type=cardano-wallet");
 
             Ok(Arc::new(CardanoWalletSink::new(
-                cardano_wallet_url,
+                cardano_wallet_base_url,
                 cardano_wallet_wallet_id,
                 cardano_wallet_passphrase,
                 cardano_wallet_payment_addr,

--- a/docker/prism-test/compose-ci-blockfrost.yml
+++ b/docker/prism-test/compose-ci-blockfrost.yml
@@ -185,9 +185,9 @@ services:
       NPRISM_BLOCKFROST_BASE_URL: http://bf-proxy:3000
       NPRISM_BLOCKFROST_POLL_INTERVAL: 1s
       NPRISM_CARDANO_NETWORK: custom
+      NPRISM_CARDANO_WALLET_BASE_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_PASSPHRASE: super_secret
       NPRISM_CARDANO_WALLET_PAYMENT_ADDR: addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3
-      NPRISM_CARDANO_WALLET_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_WALLET_ID: 9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d
       NPRISM_CONFIRMATION_BLOCKS: '0'
       NPRISM_DB_URL: postgres://postgres:postgres@db-neoprism:5432/postgres

--- a/docker/prism-test/compose-ci-sqlite.yml
+++ b/docker/prism-test/compose-ci-sqlite.yml
@@ -120,9 +120,9 @@ services:
       NPRISM_CARDANO_DBSYNC_POLL_INTERVAL: 1s
       NPRISM_CARDANO_DBSYNC_URL: postgresql://postgres:postgres@db-dbsync:5432/postgres
       NPRISM_CARDANO_NETWORK: custom
+      NPRISM_CARDANO_WALLET_BASE_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_PASSPHRASE: super_secret
       NPRISM_CARDANO_WALLET_PAYMENT_ADDR: addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3
-      NPRISM_CARDANO_WALLET_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_WALLET_ID: 9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d
       NPRISM_CONFIRMATION_BLOCKS: '0'
       NPRISM_DB_URL: 'sqlite::memory:'

--- a/docker/prism-test/compose-ci.yml
+++ b/docker/prism-test/compose-ci.yml
@@ -138,9 +138,9 @@ services:
       NPRISM_CARDANO_DBSYNC_POLL_INTERVAL: 1s
       NPRISM_CARDANO_DBSYNC_URL: postgresql://postgres:postgres@db-dbsync:5432/postgres
       NPRISM_CARDANO_NETWORK: custom
+      NPRISM_CARDANO_WALLET_BASE_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_PASSPHRASE: super_secret
       NPRISM_CARDANO_WALLET_PAYMENT_ADDR: addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3
-      NPRISM_CARDANO_WALLET_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_WALLET_ID: 9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d
       NPRISM_CONFIRMATION_BLOCKS: '0'
       NPRISM_DB_URL: postgres://postgres:postgres@db-neoprism:5432/postgres

--- a/docker/prism-test/compose-sqlite.yml
+++ b/docker/prism-test/compose-sqlite.yml
@@ -182,9 +182,9 @@ services:
       NPRISM_CARDANO_DBSYNC_POLL_INTERVAL: 1s
       NPRISM_CARDANO_DBSYNC_URL: postgresql://postgres:postgres@db-dbsync:5432/postgres
       NPRISM_CARDANO_NETWORK: custom
+      NPRISM_CARDANO_WALLET_BASE_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_PASSPHRASE: super_secret
       NPRISM_CARDANO_WALLET_PAYMENT_ADDR: addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3
-      NPRISM_CARDANO_WALLET_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_WALLET_ID: 9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d
       NPRISM_CONFIRMATION_BLOCKS: '0'
       NPRISM_DB_URL: 'sqlite::memory:'

--- a/docker/prism-test/compose.yml
+++ b/docker/prism-test/compose.yml
@@ -200,9 +200,9 @@ services:
       NPRISM_CARDANO_DBSYNC_POLL_INTERVAL: 1s
       NPRISM_CARDANO_DBSYNC_URL: postgresql://postgres:postgres@db-dbsync:5432/postgres
       NPRISM_CARDANO_NETWORK: custom
+      NPRISM_CARDANO_WALLET_BASE_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_PASSPHRASE: super_secret
       NPRISM_CARDANO_WALLET_PAYMENT_ADDR: addr_test1qp83v2wq3z9mkcjj5ejlupgwt6tcly5mtmz36rpm8w4atvqd5jzpz23y8l4dwfd9l46fl2p86nmkkx5keewdevqxhlyslv99j3
-      NPRISM_CARDANO_WALLET_URL: http://cardano-wallet:8090/v2
       NPRISM_CARDANO_WALLET_WALLET_ID: 9263a1248b046fe9e1aabc4134b03dc5c3a7ee3d
       NPRISM_CONFIRMATION_BLOCKS: '0'
       NPRISM_DB_URL: postgres://postgres:postgres@db-neoprism:5432/postgres

--- a/docs/src/configuration/submitter.md
+++ b/docs/src/configuration/submitter.md
@@ -27,7 +27,7 @@ Uses a [Cardano wallet](https://github.com/CardanoSolutions/cardano-wallet) serv
 
 | Flag | Environment Variable | Description |
 |------|---------------------|-------------|
-| `--cardano-wallet-url` | `NPRISM_CARDANO_WALLET_URL` | Base URL of the Cardano wallet service |
+| `--cardano-wallet-base-url` | `NPRISM_CARDANO_WALLET_BASE_URL` | Base URL of the Cardano wallet service |
 | `--cardano-wallet-wallet-id` | `NPRISM_CARDANO_WALLET_WALLET_ID` | Wallet ID to use for transactions |
 | `--cardano-wallet-passphrase` | `NPRISM_CARDANO_WALLET_PASSPHRASE` | Passphrase for the wallet |
 | `--cardano-wallet-payment-addr` | `NPRISM_CARDANO_WALLET_PAYMENT_ADDR` | Payment address for transactions |

--- a/tools/compose_gen/services/neoprism.py
+++ b/tools/compose_gen/services/neoprism.py
@@ -208,7 +208,7 @@ def _add_dlt_sink_env(env: dict[str, str], sink: DltSink) -> None:
     """Add DLT sink-specific environment variables."""
     if isinstance(sink, CardanoWalletSink):
         env["NPRISM_DLT_SINK_TYPE"] = "cardano-wallet"
-        env["NPRISM_CARDANO_WALLET_URL"] = (
+        env["NPRISM_CARDANO_WALLET_BASE_URL"] = (
             f"http://{sink.wallet_host}:{sink.wallet_port}/v2"
         )
         env["NPRISM_CARDANO_WALLET_WALLET_ID"] = sink.wallet_id


### PR DESCRIPTION
## Summary

Reverts the renaming introduced in PR #245 that changed `--cardano-wallet-base-url` / `NPRISM_CARDANO_WALLET_BASE_URL` / `cardano_wallet_base_url` to `--cardano-wallet-url` / `NPRISM_CARDANO_WALLET_URL` / `cardano_wallet_url`. The original `base-url` naming is more precise — the value is a base URL (e.g. `http://cardano-wallet:8090/v2`) from which specific API paths are derived, not a full endpoint URL.

## Changes

- **`bin/neoprism-node/src/cli.rs`** — Rename field `cardano_wallet_url` → `cardano_wallet_base_url` and env attribute `NPRISM_CARDANO_WALLET_URL` → `NPRISM_CARDANO_WALLET_BASE_URL`
- **`bin/neoprism-node/src/lib.rs`** — Update local variable, field access, and expect error message to reference `--cardano-wallet-base-url`
- **`docs/src/configuration/submitter.md`** — Update docs table with corrected flag and env var names
- **`tools/compose_gen/services/neoprism.py`** — Update compose generator env key
- **5 compose files** in `docker/prism-test/` — Regenerated via `python -m compose_gen.main`

No other `--cardano-wallet-*` options (`wallet-id`, `passphrase`, `payment-addr`) are affected.

## Test plan

- [x] `just check` passes clean
- [x] No remaining references to `--cardano-wallet-url` or `NPRISM_CARDANO_WALLET_URL` (without `_BASE`) in the codebase