### PR TITLE
fix(ci): upgrade JDK to 17 and pin scala-steward-action

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: Install GPG key
         uses: crazy-max/ghaction-import-gpg@v7
@@ -43,7 +43,7 @@ jobs:
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
       - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2
+        uses: scala-steward-org/scala-steward-action@ff09222640622d474d0d9f93c04aefedd125b187 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.IDENTUS_CI }}
         with:


### PR DESCRIPTION
## Problem

The Scala Steward scheduled workflow has been failing since July 12 with:

```
UnsupportedClassVersionError: org/scalasteward/core/Main has been compiled
by a more recent version of the Java Runtime (class file version 61.0),
this version of the Java Runtime only recognizes class file versions up to 55.0
```

### Failing runs

- [Run 29297383416](https://github.com/hyperledger-identus/neoprism/actions/runs/29297383416) — Jul 14
- [Run 29216602203](https://github.com/hyperledger-identus/neoprism/actions/runs/29216602203) — Jul 13
- [Run 29174691228](https://github.com/hyperledger-identus/neoprism/actions/runs/29174691228) — Jul 12

### Root Cause

The workflow uses `scala-steward-org/scala-steward-action@v2` (floating tag) without specifying `scala-steward-version`, so the action always pulls the **latest** Scala Steward binary at runtime. The action code (SHA) stays the same, but the downloaded binary version changes.

Two upstream releases broke compatibility:

- **v0.39.0** (Jul 10): Only changed the Docker base image to Java 17 — the JAR was still compiled for Java 11 (class file v55), so it continued working with JDK 11.
- **v0.39.1** (Jul 11, 21:11 UTC): PR [#3928](https://github.com/scala-steward-org/scala-steward/pull/3928) — *"Drop building with Java 11, add Java 25"* — changed the JAR bytecode target to Java 17 (class file v61). The next scheduled run (Jul 12, 01:03 UTC) pulled this new binary and crashed on JDK 11.

### Timeline

| Date (UTC) | Steward Version | JDK Config | Result |
|------------|----------------|-------------|--------|
| Jul 10 01:05 | v0.38.1 | 11 | ✅ (v0.39.0 not yet released) |
| Jul 11 01:01 | v0.39.0 | 11 | ✅ (JAR still targets Java 11) |
| Jul 12 01:03 | v0.39.1 | 11 | ❌ `UnsupportedClassVersionError` |
| Jul 13 01:03 | v0.39.1 | 11 | ❌ same |
| Jul 14 00:58 | v0.39.1 | 11 | ❌ same |

A separate transient failure on Jul 9 ([run 28986771979](https://github.com/hyperledger-identus/neoprism/actions/runs/28986771979)) was caused by HTTP 429 rate limiting when fetching the default config from GitHub — unrelated to this issue.

## Changes

1. **Bump `java-version` from `"11"` to `"17"`** — Scala Steward v0.39.1+ requires Java 17 minimum (class file v61)
2. **Pin `scala-steward-org/scala-steward-action` to SHA `ff09222640622d474d0d9f93c04aefedd125b187`** (v2) — prevents future silent breakage from upstream version bumps through the floating `@v2` tag. The `# v2` comment preserves readability.

## Testing

Triggered `workflow_dispatch` on this branch — [run 29303554615](https://github.com/hyperledger-identus/neoprism/actions/runs/29303554615) completed successfully with JDK 17 and Scala Steward v0.39.1.