### PR TITLE
fix(ci): update nixpkgs to fix crates.io 403 downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3255,11 +3255,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1768783163,
-        "narHash": "sha256-tLj4KcRDLakrlpvboTJDKsrp6z2XLwyQ4Zmo+w8KsY4=",
+        "lastModified": 1787814960,
+        "narHash": "sha256-PYZq1qzCJXC2zGI0mH07vrZBsw6DRBAOX0jN1pPtqOQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bde09022887110deb780067364a0818e89258968",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

Both Nix-based CI workflows on `main` are failing:

- **Checks** → `neoprism-check` (`nix build .#checks.x86_64-linux.default`)
- **PRISM specification test** → `run-conformance-test`, "Build neoprism image" step (`nix build .#neoprism-docker-latest`)

```
curl: (22) The requested URL returned error: 403
error: cannot download crate-utoipa-scalar-0.3.0.tar.gz from any mirror
error: Cannot build '...cargo-vendor-dir.drv'.  Reason: 1 dependency failed.
```

## Root cause

Not a code regression — the last green run on `main` was Aug 19, and everything merged since is Dependabot/Actions bumps with identical Rust deps.

crates.io's CDN now returns **HTTP 403 to plain `curl/*` User-Agents** on `https://crates.io/api/v1/crates/<crate>/<version>/download`. Reproduced outside CI (any crate, e.g. `serde`):

| Request | Result |
|---|---|
| default curl UA → crates.io API endpoint | **403** |
| `cargo/1.85.0` UA → crates.io API endpoint | 302 (OK) |
| default curl UA → `static.crates.io` | 200 (OK) |

The pinned nixpkgs (`bde0902`, 2026-01-19) fetches each crate tarball from that blocked endpoint via `fetchurl` (default curl UA), so every non-cached crate fetch fails.

## Fix

Update the `nixpkgs` flake input (`bde0902` 2026-01-19 → `c27cdad` 2026-08-27). Newer nixpkgs Rust fetchers download from **`static.crates.io`** with a `nixpkgs-fetchCargoVendor/2` User-Agent (upstream change referencing rust-lang/crates.io#13482), which is not affected by the new CDN policy.

## Verification

Built locally with the exact CI commands:

- ✅ `nix build .#checks.x86_64-linux.default` — full fmt/test/clippy/feature-gate suite passed
- ✅ `nix build .#neoprism-docker-latest` — image builds and `docker load`s
- ✅ `nix build .#checks.x86_64-linux.tools` — previously-green job, no regression