### PR TITLE
ci: bump lint-files.yml workflow pin for editorconfig-checker v3

### DIFF
--- a/.github/workflows/file-hygiene.yml
+++ b/.github/workflows/file-hygiene.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   lint:
-    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@f2c9e417fa46f69b015a9cdbaafdfb9e52e4ed60 # main
+    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@b5e934e6d44ea4ff18db76f9eae0405ee4378bd6 # main


### PR DESCRIPTION
## What
- Bumps the `hyperledger-identus/.github` `lint-files.yml` workflow pin in `file-hygiene.yml` from `f2c9e41` to `b5e934e` — the current `main` HEAD of [hyperledger-identus/.github](https://github.com/hyperledger-identus/.github), i.e. the squash-merge of hyperledger-identus/.github#8

## Why
The `File Hygiene (editorconfig)` job is currently failing on **all PRs** with:

```
##[error]Error: The binary 'ec-linux-amd64*' not found
```

Upstream `editorconfig-checker` v4.0.0 renamed its release assets, breaking the v2 action. The fix (action v3.0.0) is merged in the shared workflow repo (hyperledger-identus/.github#8) — this PR picks it up here.

Same fix as hyperledger-identus/cloud-agent#1879. That PR pins the pre-squash commit `c52da350` (content-identical `lint-files.yml`); this PR pins the merged `main` HEAD `b5e934e` directly.
