### PR TITLE
fix(docs): remove obsolete mdbook-linkcheck dependency

### DIFF
--- a/nix/docs/default.nix
+++ b/nix/docs/default.nix
@@ -26,7 +26,6 @@
           mdbook
           mdbook-cmdrun
           mdbook-d2
-          mdbook-linkcheck
           yq-go
           self'.packages.neoprism-bin
         ];

--- a/nix/docs/docs-site.nix
+++ b/nix/docs/docs-site.nix
@@ -6,7 +6,6 @@
   mdbook,
   mdbook-d2,
   mdbook-cmdrun,
-  mdbook-linkcheck,
   yq-go,
   neoprism-bin,
 }:
@@ -22,7 +21,6 @@ stdenv.mkDerivation {
     mdbook
     mdbook-cmdrun
     mdbook-d2
-    mdbook-linkcheck
     neoprism-bin
     yq-go
   ];


### PR DESCRIPTION
The docs workflow currently fails during Nix evaluation because nixpkgs removed `mdbook-linkcheck`. The package is not configured or used, so remove it from the docs package and shell inputs.

Validation: `nix build .#docs-site -L`